### PR TITLE
Fix dateparser error

### DIFF
--- a/main/const.py
+++ b/main/const.py
@@ -29,6 +29,7 @@ ABSENT_REASON_MAP = {
 LOG_FORMAT = "[%(asctime)s] %(message)s"
 
 DEFAULT_DATE_FORMAT = "%Y-%m-%d"
+ABSENT_DATE_FORMAT = "%d-%m-%Y"
 DEFAULT_MONTH_FORMAT = "%m-%Y"
 EVENT_DATE_FORMAT = "%d %B"
 

--- a/main/service.py
+++ b/main/service.py
@@ -262,8 +262,14 @@ class HurmaService:
         """
         Calculate amount of days between `date` and current date.
         """
-        date_to = dateparser.parse(date)
-        current_date = dateparser.parse(self.get_current_date())
+        date_to = dateparser.parse(
+            date_string=date,
+            date_formats=[const.ABSENT_DATE_FORMAT],
+        )
+        current_date = dateparser.parse(
+            date_string=self.get_current_date(),
+            date_formats=[const.DEFAULT_DATE_FORMAT],
+        )
         return (date_to - current_date).days + 1
 
     @staticmethod


### PR DESCRIPTION
1. Add date format for absent employees from Hurma API response to constants.
2. Add `date_formats` to dateparser parse method